### PR TITLE
Issue#3 Fix - setIsNewEntity(false) function call is added in DBPersistenceManager::mergeChildren

### DIFF
--- a/Projects/Framework/Runtime/src/oracle/ateam/sample/mobile/v2/persistence/manager/DBPersistenceManager.java
+++ b/Projects/Framework/Runtime/src/oracle/ateam/sample/mobile/v2/persistence/manager/DBPersistenceManager.java
@@ -1332,6 +1332,7 @@ public class DBPersistenceManager
         for (Entity child : children)
         {
           mergeEntity(child, doCommit);
+          child.setIsNewEntity(false);
         }        
       }
     }


### PR DESCRIPTION
Hey Steven,

As your suggestion, I have applied the local fix by adding child.setIsNewEntity(false) in DBPersistenceManager::mergeChildren function. I have tested and it works as my previous suggestion does.

Regarding the the $revision_history$ lines at the top of the classes, I thought you are not going to change oracle.ateam.sample.mobile.persistence (v1) package any more. Therefore, I have applied the fix to only oracle.ateam.sample.mobile.v2.persistence package.

You can safely merge the fix now. Thanks for this great framework.
#3
